### PR TITLE
Attempt to correct the DID spec URI fixes #3

### DIFF
--- a/common.js
+++ b/common.js
@@ -71,7 +71,7 @@ var ccg = {
     },
     "DID": {
       title: "Decentralized Identifiers 1.0",
-      href: "https://w3c.github.io/web-ledger/",
+      href: "https://w3c-ccg.github.io/did-spec/",
       authors: [
         "Drummond Reed",
       	"Manu Sporny",


### PR DESCRIPTION
Using https://w3c-ccg.github.io/did-spec/